### PR TITLE
List more than one domain with single command

### DIFF
--- a/rsdns-list.sh
+++ b/rsdns-list.sh
@@ -68,6 +68,7 @@ BEGIN { RS = ";" }
 
 }
 
+DOMAINS=( )
 #Get options from the command line.
 while getopts "u:a:c:d::hkq" option
 do
@@ -75,7 +76,7 @@ do
 		u	) RSUSER=$OPTARG ;;
 		a	) RSAPIKEY=$OPTARG ;;
 		c	) USERID=$OPTARG ;;
-		d	) DOMAIN=$OPTARG ;;
+		d	) DOMAINS=( "${DOMAINS[@]}" "$OPTARG") ;;
 		h	) usage;exit 0 ;;
 		q	) QUIET=1 ;;
 		k	) UKAUTH=1 ;;
@@ -101,11 +102,14 @@ if test -z $MGMTSVR
 fi
 
 #if a domain is given, print records, else print domaints
-if [ -z "$DOMAIN" ]
+if [ -z "${DOMAINS[0]}" ]
 	then
 	print_domains 
 else
+	for DOMAIN in "${DOMAINS[@]}"
+	do
 	print_records
+	done
 fi
 
 #done


### PR DESCRIPTION
I've experimented with allowing listing more than one domain with a single rsdns-list command:

```
rsdns-list -d domain1.com -d domain2.com
```

It would be better if it consolidated them into one list, rather than just running print_records over and over, but I thought I'd show you want I have so far.
