### PR TITLE
Useful script for managing all the other scripts

### DIFF
--- a/rsdns
+++ b/rsdns
@@ -16,7 +16,8 @@ then
 	shift
 	$LOCATION/rsdns-$COMMAND.sh $@
 else
+	#TODO: Improve output of this bit
 	echo "Available commands:"
 	cd $LOCATION
-	ls rsdns-*.sh
+	ls rsdns-*.sh | sed "s/rsdns-\(.*\)\.sh/  \1/"
 fi


### PR DESCRIPTION
Allows calling subcommands similar to git e.g. `rsdns-list` becomes `rsdns list` and only a symlink to
the rsdns command itself needs to be in /usr/local/bin or wherever.

Use:

```
ln -s /path/to/rsdns /usr/local/bin
```

adjusting paths as necessary to enable

I've been using it for a while, but I've just rewritten it to use the symlink to figure out where to find the other commands, and added it to the repository.
