### PR TITLE
Removed explicit exit with error from update methods to have them exit c...

### DIFF
--- a/rsdns-a.sh
+++ b/rsdns-a.sh
@@ -152,7 +152,6 @@ fi
 if [ -n "$UPDATE" ]
   then
   update_a
-  exit 1
 fi
 
 if [ -n "$DEL" ]

--- a/rsdns-aaaa.sh
+++ b/rsdns-aaaa.sh
@@ -152,7 +152,6 @@ fi
 if [ -n "$UPDATE" ]
   then
   update_aaaa
-  exit 1
 fi
 
 if [ -n "$DEL" ]

--- a/rsdns-cn.sh
+++ b/rsdns-cn.sh
@@ -149,7 +149,6 @@ fi
 if [ -n "$UPDATE" ]
   then
   update_cn
-  exit 1
 fi
 
 if [ -n "$DEL" ]


### PR DESCRIPTION
...leanly

Each update function had an explicit 'exit 1' removed that to expose true exit code from the update function. This was done to allow other utilities to automate updates and get appropriate exit codes. 
