### PR TITLE
Rackspace updated their auth API to reverse the order of the return para...

### DIFF
--- a/lib/auth.sh
+++ b/lib/auth.sh
@@ -42,8 +42,8 @@ function get_auth () {
 		
 	EC=`echo $AUTH|awk -F, '{print $1}'`
 	if [[ $EC == "204" ]]; then
-		TOKEN=`echo $AUTH|awk -F, '{print $2}'`
-		MGMTSVR=`echo $AUTH|awk -F, '{print $3}'`
+		TOKEN=`echo $AUTH|awk -F, '{print $3}'`
+		MGMTSVR=`echo $AUTH|awk -F, '{print $2}'`
 		if [[ ! -n $USERID ]]; then
 		  USERID=`echo $MGMTSVR | awk -F "/" '{print $5}'`
 		fi


### PR DESCRIPTION
...meters, making RSDNS fail w/o this change...
