### PR TITLE
Quote $MGMTSVR because it can have multiple values

### DIFF
--- a/rsdns-a.sh
+++ b/rsdns-a.sh
@@ -43,18 +43,18 @@ function create_a () {
   fi
 
      get_domain $NAME
-  
+
 
      check_domain
-    
+
     if [ $FOUND -eq 1 ]
     then
-      
+
       #RSPOST='{"records":[{ "type" : "A", "name" : "b.test.linickx.co.uk", "data" : "192.168.192.1", "ttl" : 86400 }]}'
       RSPOST=`echo '{"records":[{ "type" : "A", "name" : "'$NAME'", "data" : "'$IP'", "ttl" : '$TTL' }]}'`
-      
+
       create_record
-  
+
     fi
 }
 
@@ -67,29 +67,29 @@ function update_a() {
   fi
 
   get_domain $NAME
-  
+
   RECORDTYPE="A"
-  
+
   get_recordid
-  
+
       RSPOST=`echo '{ "name" : "'$NAME'", "data" : "'$IP'", "ttl" : '$TTL' }'`
-  
+
       RC=`curl -A "rsdns/$RSDNS_VERSION (https://github.com/linickx/rsdns)" -k -s -X PUT -H X-Auth-Token:\ $TOKEN -H Content-Type:\ application/json  -H Accept:\ application/json $DNSSVR/$USERID/domains/$DOMAINID/records/$RECORDID --data "$RSPOST" |tr -s '[:cntrl:]' "\n"`
-      
+
     rackspace_cloud
 }
 
 function delete_a () {
 
   get_domain $NAME
-  
+
   RECORDTYPE="A"
 
   delete_record
 
 }
 
-#prints words for master rsdns script output 
+#prints words for master rsdns script output
 function words () {
     printf "Manage A records, host records for IPv4 \n"
 }
@@ -132,14 +132,14 @@ fi
 #If the authentication works this will return $TOKEN and $MGMTSVR for use by everything else.
 get_auth $RSUSER $RSAPIKEY
 if test -z $TOKEN
-    then 
+    then
     if [[ $QUIET -eq 0 ]]; then
         echo Auth Token does not exist.
     fi
     exit 98
 fi
-if test -z $MGMTSVR
-    then 
+if test -z "$MGMTSVR"
+    then
     if [[ $QUIET -eq 0 ]]; then
         echo Management Server does not exist.
     fi

--- a/rsdns-aaaa.sh
+++ b/rsdns-aaaa.sh
@@ -43,18 +43,18 @@ function create_aaaa () {
   fi
 
      get_domain $NAME
-  
+
 
      check_domain
-    
+
     if [ $FOUND -eq 1 ]
     then
-      
+
       #RSPOST='{"records":[{ "type" : "AAAA", "name" : "b.test.linickx.co.uk", "data" : "4321:0:1:2:3:4:567:89ab", "ttl" : 86400 }]}'
       RSPOST=`echo '{"records":[{ "type" : "AAAA", "name" : "'$NAME'", "data" : "'$IP'", "ttl" : '$TTL' }]}'`
-      
+
       create_record
-  
+
     fi
 }
 
@@ -67,29 +67,29 @@ function update_aaaa() {
   fi
 
   get_domain $NAME
-  
+
   RECORDTYPE="AAAA"
-  
+
   get_recordid
-  
+
       RSPOST=`echo '{ "name" : "'$NAME'", "data" : "'$IP'", "ttl" : '$TTL' }'`
-  
+
       RC=`curl -A "rsdns/$RSDNS_VERSION (https://github.com/linickx/rsdns)" -k -s -X PUT -H X-Auth-Token:\ $TOKEN -H Content-Type:\ application/json  -H Accept:\ application/json $DNSSVR/$USERID/domains/$DOMAINID/records/$RECORDID --data "$RSPOST" |tr -s '[:cntrl:]' "\n"`
-      
+
     rackspace_cloud
 }
 
 function delete_aaaa () {
 
   get_domain $NAME
-  
+
   RECORDTYPE="AAAA"
 
   delete_record
 
 }
 
-#prints words for master rsdns script output 
+#prints words for master rsdns script output
 function words () {
     printf "Manage AAAA records, host records for IPv6 \n"
 }
@@ -132,14 +132,14 @@ fi
 #If the authentication works this will return $TOKEN and $MGMTSVR for use by everything else.
 get_auth $RSUSER $RSAPIKEY
 if test -z $TOKEN
-    then 
+    then
     if [[ $QUIET -eq 0 ]]; then
         echo Auth Token does not exist.
     fi
     exit 98
 fi
-if test -z $MGMTSVR
-    then 
+if test -z "$MGMTSVR"
+    then
     if [[ $QUIET -eq 0 ]]; then
         echo Management Server does not exist.
     fi

--- a/rsdns-cn.sh
+++ b/rsdns-cn.sh
@@ -42,16 +42,16 @@ function create_cn () {
   fi
 
   get_domain $NAME
-  
+
   check_domain
-    
+
     if [ $FOUND -eq 1 ]
     then
-      
+
       RSPOST=`echo '{"records":[{ "type" : "CNAME", "name" : "'$NAME'", "data" : "'$CNAME'", "ttl" : '$TTL' }]}'`
-      
+
       create_record
-  
+
     fi
 }
 
@@ -64,15 +64,15 @@ function update_cn() {
   fi
 
   get_domain $NAME
-  
+
   RECORDTYPE="CNAME"
-  
+
   get_recordid
-  
+
       RSPOST=`echo '{ "name" : "'$NAME'", "data" : "'$CNAME'", "ttl" : '$TTL' }'`
-  
+
       RC=`curl -A "rsdns/$RSDNS_VERSION (https://github.com/linickx/rsdns)" -k -s -X PUT -H X-Auth-Token:\ $TOKEN -H Content-Type:\ application/json  -H Accept:\ application/json $DNSSVR/$USERID/domains/$DOMAINID/records/$RECORDID --data "$RSPOST" |tr -s '[:cntrl:]' "\n"`
-      
+
     rackspace_cloud
 
 }
@@ -80,14 +80,14 @@ function update_cn() {
 function delete_cn () {
 
   get_domain $NAME
-  
+
   RECORDTYPE="CNAME"
 
   delete_record
 
 }
 
-#prints words for master rsdns script output 
+#prints words for master rsdns script output
 function words () {
     printf "Manage canonical name (CNAME) records \n"
 }
@@ -130,14 +130,14 @@ fi
 #If the authentication works this will return $TOKEN and $MGMTSVR for use by everything else.
 get_auth $RSUSER $RSAPIKEY
 if test -z $TOKEN
-    then 
+    then
     if [[ $QUIET -eq 0 ]]; then
         echo Auth Token does not exist.
     fi
     exit 98
 fi
-if test -z $MGMTSVR
-    then 
+if test -z "$MGMTSVR"
+    then
     if [[ $QUIET -eq 0 ]]; then
         echo Management Server does not exist.
     fi

--- a/rsdns-dc.sh
+++ b/rsdns-dc.sh
@@ -50,7 +50,7 @@ function usage () {
     printf "\n"
 }
 
-#prints words for master rsdns script output 
+#prints words for master rsdns script output
 function words () {
     printf "Dynamic DNS Client for rackspace cloud DNS \n"
 }
@@ -81,8 +81,8 @@ if [ -z $HOST ]
     HOST="www.google.com"
 fi
 
-if ! ping -c 3 $HOST &>/dev/null  
-then 
+if ! ping -c 3 $HOST &>/dev/null
+then
     if [[ $QUIET -eq 0 ]]; then
         echo "The Internet is down, cannot ping $HOST"
     fi
@@ -102,14 +102,14 @@ then
     # Authenticate and get started
     get_auth $RSUSER $RSAPIKEY
     if test -z $TOKEN
-        then 
+        then
         if [[ $QUIET -eq 0 ]]; then
             echo Auth Token does not exist.
         fi
         exit 98
     fi
-    if test -z $MGMTSVR
-        then 
+    if test -z "$MGMTSVR"
+        then
         if [[ $QUIET -eq 0 ]]; then
             echo Management Server does not exist.
         fi
@@ -128,9 +128,9 @@ then
 
     # POST!
     RSPOST=`echo '{ "name" : "'$NAME'", "data" : "'$IP'" }'`
-  
+
     RC=`curl -A "rsdns/$RSDNS_VERSION (https://github.com/linickx/rsdns)" -k -s -X PUT -H X-Auth-Token:\ $TOKEN -H Content-Type:\ application/json  -H Accept:\ application/json $DNSSVR/$USERID/domains/$DOMAINID/records/$RECORDID --data "$RSPOST" |tr -s '[:cntrl:]' "\n"`
-    
+
     UPDATE=1
     rackspace_cloud
 fi

--- a/rsdns-dc6.sh
+++ b/rsdns-dc6.sh
@@ -50,7 +50,7 @@ function usage () {
     printf "\n"
 }
 
-#prints words for master rsdns script output 
+#prints words for master rsdns script output
 function words () {
     printf "Dynamic DNS Client for rackspace cloud DNS for IPv6 \n"
 }
@@ -81,8 +81,8 @@ if [ -z $HOST ]
     HOST="www.google.com"
 fi
 
-if ! ping6 -c 3 $HOST &>/dev/null  
-then 
+if ! ping6 -c 3 $HOST &>/dev/null
+then
     if [[ $QUIET -eq 0 ]]; then
         echo "The Internet is down, cannot ping6 $HOST"
     fi
@@ -102,14 +102,14 @@ then
     # Authenticate and get started
     get_auth $RSUSER $RSAPIKEY
     if test -z $TOKEN
-        then 
+        then
         if [[ $QUIET -eq 0 ]]; then
             echo Auth Token does not exist.
         fi
         exit 98
     fi
-    if test -z $MGMTSVR
-        then 
+    if test -z "$MGMTSVR"
+        then
         if [[ $QUIET -eq 0 ]]; then
             echo Management Server does not exist.
         fi
@@ -128,9 +128,9 @@ then
 
     # POST!
     RSPOST=`echo '{ "name" : "'$NAME'", "data" : "'$IP'" }'`
-  
+
     RC=`curl -A "rsdns/$RSDNS_VERSION (https://github.com/linickx/rsdns)" -k -s -X PUT -H X-Auth-Token:\ $TOKEN -H Content-Type:\ application/json  -H Accept:\ application/json $DNSSVR/$USERID/domains/$DOMAINID/records/$RECORDID --data "$RSPOST" |tr -s '[:cntrl:]' "\n"`
-            
+
     UPDATE=1
     rackspace_cloud
 fi

--- a/rsdns-did.sh
+++ b/rsdns-did.sh
@@ -29,7 +29,7 @@ function usage () {
     printf "\n"
 }
 
-#prints words for master rsdns script output 
+#prints words for master rsdns script output
 function words () {
     printf "Delete records by ID \n"
 }
@@ -74,14 +74,14 @@ fi
 #If the authentication works this will return $TOKEN and $MGMTSVR for use by everything else.
 get_auth $RSUSER $RSAPIKEY
 if test -z $TOKEN
-    then 
+    then
     if [[ $QUIET -eq 0 ]]; then
         echo Auth Token does not exist.
     fi
     exit 98
 fi
-if test -z $MGMTSVR
-    then 
+if test -z "$MGMTSVR"
+    then
     if [[ $QUIET -eq 0 ]]; then
         echo Management Server does not exist.
     fi

--- a/rsdns-domain.sh
+++ b/rsdns-domain.sh
@@ -42,27 +42,27 @@ if [ -z $EMAIL ]
 
   # {"domains":[{"name":"example.com","ttl":86400,"emailAddress":"me@example.com"}]}
   RSPOST=`echo '{"domains":[{ "name" : "'$DOMAIN'", "emailAddress" : "'$EMAIL'", "ttl" : '$TTL' }]}'`
-  
+
   RCOUTPUT="domain"
-  
+
   RC=`curl -A "rsdns/$RSDNS_VERSION (https://github.com/linickx/rsdns)" -k -s -X POST -H X-Auth-Token:\ $TOKEN -H Content-Type:\ application/json  -H Accept:\ application/json $DNSSVR/$USERID/domains/ --data "$RSPOST" |tr -s '[:cntrl:]' "\n"`
-      
+
   #echo $RSPOST
-  
+
   rackspace_cloud
 
 }
 
 function delete_domain() {
-  
+
   check_domain
-  
+
   RC=`curl -A "rsdns/$RSDNS_VERSION (https://github.com/linickx/rsdns)" -k -s -X DELETE -H X-Auth-Token:\ $TOKEN -H Content-Type:\ application/json  -H Accept:\ application/json $DNSSVR/$USERID/domains/$DOMAINID|tr -s '[:cntrl:]' "\n"`
-  
+
   rackspace_cloud
 }
 
-#prints words for master rsdns script output 
+#prints words for master rsdns script output
 function words () {
     printf "Create & delete domains hosted by rackspace cloud DNS \n"
 }
@@ -103,14 +103,14 @@ fi
 #If the authentication works this will return $TOKEN and $MGMTSVR for use by everything else.
 get_auth $RSUSER $RSAPIKEY
 if test -z $TOKEN
-    then 
+    then
     if [[ $QUIET -eq 0 ]]; then
         echo Auth Token does not exist.
     fi
     exit 98
 fi
-if test -z $MGMTSVR
-    then 
+if test -z "$MGMTSVR"
+    then
     if [[ $QUIET -eq 0 ]]; then
         echo Management Server does not exist.
     fi

--- a/rsdns-export.sh
+++ b/rsdns-export.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# rsdns-export.sh - Used to export domains 
+# rsdns-export.sh - Used to export domains
 #
 
 # config file for variables.
@@ -30,36 +30,36 @@ function usage () {
     printf "\n"
 }
 
-#prints words for master rsdns script output 
+#prints words for master rsdns script output
 function words () {
     printf "Export domains in bind format \n"
 }
 
 #
 function get_export() {
-    
+
     check_domain
 
     if [ $FOUND -eq 1 ]
     then
 
         DOMEXPORT=`curl -A "rsdns/$RSDNS_VERSION (https://github.com/linickx/rsdns)" -k -s -X GET -H X-Auth-Token:\ $TOKEN $DNSSVR/$USERID/domains/$DOMAINID/export|tr -s '[:cntrl:]' "\n"`
-        
+
         JQ_DOMEXPORT_STATUS=`echo $DOMEXPORT | jq .status | tr -d '"'`
         echo "Job status is: $JQ_DOMEXPORT_STATUS"
-        
-        JQ_DOMEXPORT_CALLBACK=`echo $DOMEXPORT | jq .callbackUrl | tr -d '"'` 
-        
+
+        JQ_DOMEXPORT_CALLBACK=`echo $DOMEXPORT | jq .callbackUrl | tr -d '"'`
+
         if [ "$JQ_DOMEXPORT_STATUS" == "RUNNING" ]
         then
             while true; do
 
                 DOMEXPORT=`curl -A "rsdns/$RSDNS_VERSION (https://github.com/linickx/rsdns)" -k -s -X GET -H X-Auth-Token:\ $TOKEN $JQ_DOMEXPORT_CALLBACK?showDetails=true|tr -s '[:cntrl:]' "\n"`
-                
+
                 JQ_DOMEXPORT_STATUS=`echo $DOMEXPORT | jq .status | tr -d '"'`
                 echo "Job status is: $JQ_DOMEXPORT_STATUS"
-                echo 
-                
+                echo
+
                 if [ "$JQ_DOMEXPORT_STATUS" == "COMPLETED" ]
                 then
                     if [ -n "$OFILE" ]; then
@@ -104,14 +104,14 @@ done
 #If the authentication works this will return $TOKEN and $MGMTSVR for use by everything else.
 get_auth $RSUSER $RSAPIKEY
 if test -z $TOKEN
-    then 
+    then
     if [[ $QUIET -eq 0 ]]; then
         echo Auth Token does not exist.
     fi
     exit 98
 fi
-if test -z $MGMTSVR
-    then 
+if test -z "$MGMTSVR"
+    then
     if [[ $QUIET -eq 0 ]]; then
         echo Management Server does not exist.
     fi
@@ -124,7 +124,7 @@ if [ -z "$DOMAIN" ]
         echo "Which domain do you want to export?"
         echo "use the -d switch"
         echo
-    print_domains 
+    print_domains
 else
     if [[ $SOFILE -eq 1 ]];then
         if [ -z "$OFILE" ]; then

--- a/rsdns-list.sh
+++ b/rsdns-list.sh
@@ -43,7 +43,7 @@ function print_records() {
 
 }
 
-#prints words for master rsdns script output 
+#prints words for master rsdns script output
 function words () {
     printf "List domains and records hosted by rackspace \n"
 }
@@ -67,14 +67,14 @@ done
 #If the authentication works this will return $TOKEN and $MGMTSVR for use by everything else.
 get_auth $RSUSER $RSAPIKEY
 if test -z $TOKEN
-    then 
+    then
     if [[ $QUIET -eq 0 ]]; then
         echo Auth Token does not exist.
     fi
     exit 98
 fi
-if test -z $MGMTSVR
-    then 
+if test -z "$MGMTSVR"
+    then
     if [[ $QUIET -eq 0 ]]; then
         echo Management Server does not exist.
     fi
@@ -84,7 +84,7 @@ fi
 #if a domain is given, print records, else print domaints
 if [ -z "$DOMAIN" ]
     then
-    print_domains 
+    print_domains
 else
     print_records
 fi

--- a/rsdns-mx.sh
+++ b/rsdns-mx.sh
@@ -39,31 +39,31 @@ function create_mx () {
     usage
     exit 1
   fi
-  
+
   check_domain
-    
+
     if [ $FOUND -eq 1 ]
     then
-      
+
       RSPOST=`echo '{"records":[{ "priority" : '$PRIORITY',"type" : "MX", "name" : "'$NAME'", "data" : "'$DATA'", "ttl" : '$TTL' }]}'`
       RCOUTPUT="mx"
-      
+
      create_record
-      
+
     fi
 }
 
 function delete_mx() {
- 
+
   get_domain $NAME
-  
+
   RECORDTYPE="MX"
 
   delete_record
- 
+
 }
 
-#prints words for master rsdns script output 
+#prints words for master rsdns script output
 function words () {
     printf "Manage mail exchange (MX) records \n"
 }
@@ -117,14 +117,14 @@ fi
 #If the authentication works this will return $TOKEN and $MGMTSVR for use by everything else.
 get_auth $RSUSER $RSAPIKEY
 if test -z $TOKEN
-    then 
+    then
     if [[ $QUIET -eq 0 ]]; then
         echo Auth Token does not exist.
     fi
     exit 98
 fi
-if test -z $MGMTSVR
-    then 
+if test -z "$MGMTSVR"
+    then
     if [[ $QUIET -eq 0 ]]; then
         echo Management Server does not exist.
     fi

--- a/rsdns-ns.sh
+++ b/rsdns-ns.sh
@@ -37,46 +37,46 @@ function update_ns() {
     RECORDTYPE="NS"
 
     get_records
-   
+
     FOUND=0
-   
-    
+
+
     for i in `echo $RECORDS | awk -F, 'BEGIN { RS = ";" } ; {print}' `
     do
         i=`echo $i | grep $RECORDTYPE`
-    
+
         iNAME=`echo $i  | awk -F "\"*,\"*" '{print $4}'`
 
         iRECORDID=`echo $i  | awk -F "\"*,\"*" '{print $2}'`
-        
+
         if [ "$iNAME" == "$OLDNS" ]
         then
             FOUND=1
             RECORDID=$iRECORDID
         fi
     done
-    
+
     if [ $FOUND -eq 0 ]
     then
-        printf "\n" 
+        printf "\n"
         printf "record for %s not found." $OLDNS
         printf "\n"
         exit 96
     fi
 
     # { "id" : "NS-123", "type" : "NS" "name" : "example.foo.com", "data" : "ns1.foo.com", "ttl" : 54000 }
-  
+
     RSPOST=`echo '{ "name" : "'$DOMAIN'", "data" : "'$NEWNS'", "ttl" : '$TTL' }'`
-  
+
       RC=`curl -A "rsdns/$RSDNS_VERSION (https://github.com/linickx/rsdns)" -k -s -X PUT -H X-Auth-Token:\ $TOKEN -H Content-Type:\ application/json  -H Accept:\ application/json $DNSSVR/$USERID/domains/$DOMAINID/records/$RECORDID --data "$RSPOST" |tr -s '[:cntrl:]' "\n"`
-      
+
     UPDATE=1
     rackspace_cloud
 
 
 }
 
-#prints words for master rsdns script output 
+#prints words for master rsdns script output
 function words () {
     printf "Manage domain name server (NS) records \n"
 }
@@ -130,14 +130,14 @@ fi
 #If the authentication works this will return $TOKEN and $MGMTSVR for use by everything else.
 get_auth $RSUSER $RSAPIKEY
 if test -z $TOKEN
-    then 
+    then
     if [[ $QUIET -eq 0 ]]; then
         echo Auth Token does not exist.
     fi
     exit 98
 fi
-if test -z $MGMTSVR
-    then 
+if test -z "$MGMTSVR"
+    then
     if [[ $QUIET -eq 0 ]]; then
         echo Management Server does not exist.
     fi

--- a/rsdns-srv.sh
+++ b/rsdns-srv.sh
@@ -40,28 +40,28 @@ function create_srv () {
 
 
   check_domain
-    
+
     if [ $FOUND -eq 1 ]
     then
-      
+
       DATA="$WEIGHT $PORT $TARGET"
       # echo $DATA
       RSPOST=`echo '{"records":[{ "type" : "SRV", "name" : "'$NAME'", "priority" : "'$PRIORITY'", "data" : "'$DATA'", "ttl" : '$TTL' }]}'`
-      
+
      create_record
-      
+
     fi
 }
 
 function delete_srv() {
- 
+
   RECORDTYPE="SRV"
 
   delete_record
-  
+
 }
 
-#prints words for master rsdns script output 
+#prints words for master rsdns script output
 function words () {
     printf "Manage service (SRV) records \n"
 }
@@ -122,14 +122,14 @@ fi
 #If the authentication works this will return $TOKEN and $MGMTSVR for use by everything else.
 get_auth $RSUSER $RSAPIKEY
 if test -z $TOKEN
-    then 
+    then
     if [[ $QUIET -eq 0 ]]; then
         echo Auth Token does not exist.
     fi
     exit 98
 fi
-if test -z $MGMTSVR
-    then 
+if test -z "$MGMTSVR"
+    then
     if [[ $QUIET -eq 0 ]]; then
         echo Management Server does not exist.
     fi

--- a/rsdns-txt.sh
+++ b/rsdns-txt.sh
@@ -36,26 +36,26 @@ function create_txt () {
 
 
   check_domain
-    
+
     if [ $FOUND -eq 1 ]
     then
-      
+
       RSPOST=`echo '{"records":[{ "type" : "TXT", "name" : "'$NAME'", "data" : "'$DATA'", "ttl" : '$TTL' }]}'`
-      
+
      create_record
-      
+
     fi
 }
 
 function delete_txt() {
- 
+
   RECORDTYPE="TXT"
 
   delete_record
-  
+
 }
 
-#prints words for master rsdns script output 
+#prints words for master rsdns script output
 function words () {
     printf "Manage text (TXT) records \n"
 }
@@ -103,14 +103,14 @@ fi
 #If the authentication works this will return $TOKEN and $MGMTSVR for use by everything else.
 get_auth $RSUSER $RSAPIKEY
 if test -z $TOKEN
-    then 
+    then
     if [[ $QUIET -eq 0 ]]; then
         echo Auth Token does not exist.
     fi
     exit 98
 fi
-if test -z $MGMTSVR
-    then 
+if test -z "$MGMTSVR"
+    then
     if [[ $QUIET -eq 0 ]]; then
         echo Management Server does not exist.
     fi


### PR DESCRIPTION
This value is populated from values in the service catalog after
authenticating, and when the user is allowed to access multiple RAX
regions, there will be multiple URLs in there.

----------

I found this because the first time I ran `rsdns list` after setting up my profile stuff it spit this out to me:

```
ADR-works:~$ rsdns list
/Users/aregner/dev/source/rsdns-master/rsdns-list.sh: line 76: test: too many arguments
ID      | Domain
[ ... ]
```