### PR TITLE
Fix stripping of extraneous fields since totalEntries now appears first in the JSON

### DIFF
--- a/lib/func.sh
+++ b/lib/func.sh
@@ -46,7 +46,7 @@ function get_domains() {
     fi
 
     # Legacy variable/response for backward compatability
-    DOMAINS=`echo $jDOMAINS |tr -s '[:cntrl:]' "\n" |sed -e 's/{"domains":\[{//' -e 's/}\]}//' -e 's/},{/;/g' -e 's/"name"://g' -e 's/"id"://g' -e 's/"accountId"://g' -e 's/"updated"://g' -e 's/"created"://g' -e 's/"totalEntries"://g'`    
+    DOMAINS=`echo $jDOMAINS |tr -s '[:cntrl:]' "\n" |sed -e 's/"domains":\[{//' -e 's/}\]}//' -e 's/},{/;/g' -e 's/"name"://g' -e 's/"id"://g' -e 's/"accountId"://g' -e 's/"updated"://g' -e 's/"created"://g' -e 's/{"totalEntries":[0-9]*,//g'`
 }
 
 function get_records() {
@@ -79,7 +79,7 @@ function get_records() {
     fi
     #echo $jRECORDS | jq .
 
-    RECORDS=`echo $jRECORDS |tr -s '[:cntrl:]' "\n"| sed -e 's/{"records":\[{//' -e 's/}\]}//' -e 's/},{/;/g' -e 's/"name"://g' -e 's/"id"://g' -e 's/"type"://g' -e 's/"data"://g' -e 's/"updated"://g' -e 's/"created"://g' -e 's/"totalEntries"://g'`
+    RECORDS=`echo $jRECORDS |tr -s '[:cntrl:]' "\n"| sed -e 's/"records":\[{//' -e 's/}\]}//' -e 's/},{/;/g' -e 's/"name"://g' -e 's/"id"://g' -e 's/"type"://g' -e 's/"data"://g' -e 's/"updated"://g' -e 's/"created"://g' -e 's/{"totalEntries":[0-9]*,//g'`
 }
 
 function check_domain() {


### PR DESCRIPTION
Rackspace appear to have changed the order of fields in the JSON responses so totalEntries field now appears before record, e.g.
`
{"totalEntries":XX,"records":[{"id":"aaaaaaaaa-aaaaaaaaaa-aaaaaaaa","name":"example.com","type":"A","data":"10.1.1.1","ttl":3600,"updated":"2021-12-13T10:47:23.239Z","created":"2021-10-28T15:29:46.763Z"},...]}`

The existing code scripts used in get_domains and get_records then fail to strip the field names properly when processing the data. In the case of get_records this causes the very first record to be mangled - the extra comma that remains confuses AWK column selection.

This is a quick fudge to make it work again. There is probably a more elegant way to fix it once and for all if field order changes again.