### PR TITLE
Fix awk error in get_recordid function in func.sh

### DIFF
--- a/lib/func.sh
+++ b/lib/func.sh
@@ -120,7 +120,7 @@ function get_recordid() {
    
    FOUND=0
 
-    for i in `echo $RECORDS | awk -F, 'BEGIN { RS = ";" } { gsub(/\"/,"") ; print $1 "|" $2 "|" $3 "|" $4 }'`
+    for i in `echo $RECORDS | awk -F, 'BEGIN { RS = ";" } { gsub(/"/,"") ; print $1 "|" $2 "|" $3 "|" $4 }'`
     do
     
         if [ "$RECORDTYPE" == "MX" ]


### PR DESCRIPTION
In function get_recordid awk is complaining of the backsplash escaped double quote ". As this is in a literal single quote block the " need not be escaped. Removed backslash fixes this issue.